### PR TITLE
fix: Norwegian text corrections and show more button threshold

### DIFF
--- a/components/sections/ExperienceSection.tsx
+++ b/components/sections/ExperienceSection.tsx
@@ -11,7 +11,7 @@ const ExperienceCard = ({ job }: { job: JobDetail }) => {
 
   const shouldShowButton =
     (job.details && job.details.length > 1) ||
-    (job.description && job.description.length > 150)
+    (job.description && job.description.length > 100)
 
   return (
     <Card hoverable variant="experience">

--- a/data/experience.ts
+++ b/data/experience.ts
@@ -22,7 +22,7 @@ export const experienceData: JobDetail[] = [
   },
   {
     title: "Data scientist",
-    company: "Leroy Seafood, Bergen",
+    company: "Lerøy Seafood, Bergen",
     period: "2023 - 2025",
     details: [
       "Built MLOps infrastructure in Databricks, automating model deployment and launching two production-grade salmon price prediction models",

--- a/data/talks.ts
+++ b/data/talks.ts
@@ -25,7 +25,7 @@ export const talksData: Talk[] = [
     category: "AI in Medical Imaging"
   },
   {
-    title: "Leroy og kunstig intelligens",
+    title: "Lerøy og kunstig intelligens",
     location: "Inspirasjonsdag for realfagselever, Western Norway University of Applied Sciences, Bergen, Norway",
     date: "November 4, 2024",
     year: 2024,
@@ -39,8 +39,8 @@ export const talksData: Talk[] = [
     category: "AI"
   },
   {
-    title: "Leroy og kunstig intelligens",
-    location: "Leroy motivasjonssamling, Scandic Flesland, Bergen, Norway",
+    title: "Lerøy og kunstig intelligens",
+    location: "Lerøy motivasjonssamling, Scandic Flesland, Bergen, Norway",
     date: "September 7, 2024",
     year: 2024,
     category: "AI"
@@ -88,7 +88,7 @@ export const talksData: Talk[] = [
     category: "Medical Imaging"
   },
   {
-    title: "RAD230 lecture and lab: \"Hva er dyplæring?\"",
+    title: "RAD230 lecture and lab: \"Hva er dyp læring?\"",
     location: "Western Norway University of Applied Sciences, Bergen, Norway",
     date: "May 13, 2022",
     year: 2022,


### PR DESCRIPTION
- Change "Leroy" to "Lerøy" (correct Norwegian spelling)
- Change "dyplæring" to "dyp læring" (two words)
- Lower show more threshold from 150 to 100 characters to fix
  Sjøkrigsskolen description being truncated without expand option

https://claude.ai/code/session_01Cv9S4tNgWQszDg1hUN1mdF